### PR TITLE
Add documentation for installing on Ubuntu 10.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ You can also use the Turtle, just like Hackety-Hack does
     sudo apt-get install libqt4-dev
     sudo apt-get install cmake
     bundle install
+
+## If you also want Gosu
+    echo "" >> Gemfile
+    echo "# needed for gosu" >> Gemfile
+    echo "gem 'gosu'" >> Gemfile
+    sudo apt-get install g++ libgl1-mesa-dev libpango1.0-dev libboost-dev libopenal-dev libsndfile-dev libxdamage-dev libsdl-ttf2.0-dev libfreeimage3 libfreeimage-dev
+    bundle install
     
 ## Getting setup for development on a Mac using Homebrew
 I used the qtbindings gem: https://github.com/ryanmelt/qtbindings


### PR DESCRIPTION
To get kids ruby installed on Ubuntu 10.04, I had to make those 2 additions.

I propose to add them to the documentation.

HTH,

Peter
