### PR TITLE
warnings

### DIFF
--- a/app/widgets/main.rb
+++ b/app/widgets/main.rb
@@ -23,9 +23,7 @@ class MainWidget < Qt::WebView
 
     Qt::Object.connect(@frame,  SIGNAL("javaScriptWindowObjectCleared()"), 
                           self, SLOT('setupQtBridge()'))
-    Qt::Object.connect(self, SIGNAL("stdInRequested()"), 
-                          self, SLOT('acceptStdin()'))
-
+    initialize_stdin_connection
     self.load Qt::Url.new(File.expand_path(File.dirname(__FILE__) + "/../../public/index.html"))
     show
   end
@@ -43,6 +41,12 @@ class MainWidget < Qt::WebView
 
   private
   
+  def initialize_stdin_connection
+    Qt::Object.connect(self, SIGNAL("stdInRequested()"), 
+                          self, SLOT('acceptStdin()'))
+    rejectStdin
+  end
+
   def notify_stdin_event_listeners(event)
     (@fr ||= FrameWriter.new(@frame)).keyPressEvent(event)
     (@wr ||= RunnerWriter.new(@runner)).keyPressEvent(event)

--- a/app/widgets/server.rb
+++ b/app/widgets/server.rb
@@ -9,7 +9,7 @@ class KidsRubyServer < Qt::TcpServer
     super(parent)
     @parent = parent
     @turtle = turtle
-    
+
     listen(Qt::HostAddress.new(Qt::HostAddress::LocalHost), 8080)
     connect(self, SIGNAL('newConnection()'), SLOT('connection()'));
   end
@@ -34,7 +34,7 @@ class KidsRubyServer < Qt::TcpServer
           connection.waitForReadyRead(100)
         end
       end
-      
+
       while connection.isOpen
         if connection.canReadLine
           line = connection.readLine.to_s
@@ -47,11 +47,11 @@ class KidsRubyServer < Qt::TcpServer
           connection.waitForReadyRead(100)
         end
       end
-            
+
       if connection.isOpen
         body = connection.readAll.to_s
       end
-      
+
       if url && url.path =~ /\/turtle\/(.*)/
         command = $1
         param = URI.decode(url.encodedQuery.to_s)
@@ -102,19 +102,19 @@ class KidsRubyServer < Qt::TcpServer
       puts "ERROR #{$!}"
     end
   end
-  
+
   def errorResponse
     "HTTP/1.0 400 Bad Request\r\n"
   end
-  
+
   def validResponse(data)
-	  "HTTP/1.0 200 Ok\r\n" +
+    "HTTP/1.0 200 Ok\r\n" +
       "Content-Type: text/plain; charset=\"utf-8\"\r\n" +
       "\r\n" +
       "#{data}"
-	end
-	
-	def handleError(err)
-	  #todo: display something here
-	end
+  end
+
+  def handleError(err)
+    #todo: display something here
+  end
 end


### PR DESCRIPTION
The first warning was removed by initializing the @acceptStdin variable
on the main widget to false.

The second warning was removed by fixing indentation.
