### PR TITLE
support UTF-8 output for multiple languages

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -32,7 +32,8 @@ class Runner < Qt::Process
 
   def build_code_from_fragment(code)
     # add any default requires for kid code
-    new_code = "require '" + File.expand_path(File.dirname(__FILE__) + "/../../lib/kidsruby") + "'\n"
+    new_code = "# -*- coding: utf-8 -*-\n"
+    new_code << "require '" + File.expand_path(File.dirname(__FILE__) + "/../../lib/kidsruby") + "'\n"
     new_code << code
     new_code
   end

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -57,7 +57,7 @@ function copyStdIntoStdOut() {
 }
 
 function updateStdOut(newHtml) {
-  $("#stdout").append(unescape(newHtml));
+  $("#stdout").append(decodeURI(newHtml));
   scrollToOutputEnd()
 };
 


### PR DESCRIPTION
Hi,
I tried to puts a Japanese string (UTF-8) and it was not displayed on Output tab.
I made some changes so that UTF-8 characters are correctly displayed on Output tab. Please review the changes and merge if possible.
Changes:
1) Add a UTF-8 magic comment to kidcode.rb. Without the magic comment, kidcode.rb is terminated with an error such “unexpected '”.
2) Change unescape() to decodeURI() in updateStdOut(). unescape() seems not able to handle UTF-8 characters correctly. Characters are garbled on Output tab.
