### PR TITLE
Avoid stop button receiving click event on focus generated by enter key.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -249,6 +249,7 @@ $(document).ready(function() {
   $("#run").click(function(e) {
     if ($("#run").html() == 'Run') {
       resizeCanvas();
+      $("#run").blur();
       startRun(getEditor());
     } else {
       stopRun();


### PR DESCRIPTION
Hi,
After Run button is pressed, Stop button is remain focused at least under my Kidsruby environment. When kidcode.rb requires standard input and I press Enter kay, a click event on the button is generated and kidcode is terminated.
The change blurs the button before startRun(). Please review the change.
Masami,
