### PR TITLE
fix garbled UTF-8 characters when using alert and ask

### DIFF
--- a/app/widgets/main.rb
+++ b/app/widgets/main.rb
@@ -183,10 +183,12 @@ class MainWidget < Qt::WebView
   end
 
   def alert(text)
+    text.force_encoding("utf-8")
     Qt::MessageBox::information(self, tr(version_description), URI.decode(text))
   end
 
   def ask(text)
+    text.force_encoding("utf-8")
     ok = Qt::Boolean.new
     val = Qt::InputDialog.getText(self, tr(version_description),
                                   URI.decode(text), Qt::LineEdit::Normal,


### PR DESCRIPTION
Japanese characters are garbled on alert and ask dialog boxes on a windows environment. Encoding of String text, that containing UTF-8 Japanese characters, is set to "us-ascii". The problem is solved by setting encoding UTF-8. I believe internal encoding of KidsRuby is UTF-8, we safely set encoding to UTF-8. Please review the code.
