### PR TITLE
Use fully qualified constant names

### DIFF
--- a/public/help/en/robots/sphero_commands.html
+++ b/public/help/en/robots/sphero_commands.html
@@ -56,19 +56,19 @@
       <p>Pings Sphero to see if it is responding</p>
     </div>
     <div style="background: rgb(240, 248, 255); color: black" class="color">
-      <h3>FORWARD</h3>
+      <h3>Sphero::FORWARD</h3>
       <p>A constant value, same as 0</p>
     </div>
     <div style="background: rgb(240, 248, 255); color: black" class="color">
-      <h3>BACKWARD</h3>
+      <h3>Sphero::BACKWARD</h3>
       <p>A constant value, same as 180</p>
     </div>
     <div style="background: rgb(240, 248, 255); color: black" class="color">
-      <h3>RIGHT</h3>
+      <h3>Sphero::RIGHT</h3>
       <p>A constant value, same as 90</p>
     </div>
     <div style="background: rgb(240, 248, 255); color: black" class="color">
-      <h3>LEFT</h3>
+      <h3>Sphero::LEFT</h3>
       <p>A constant value, same as 270</p>
     </div>
   <p>There are more commands, but these are the most important. For more information, take a look at the Sphero gem documentation on Github.</p>

--- a/public/help/shared/robots/code1_1.rb
+++ b/public/help/shared/robots/code1_1.rb
@@ -1,16 +1,16 @@
 require 'sphero'
 
 Sphero.start '/dev/tty.Sphero-YBW-RN-SPP' do
-	roll 60, FORWARD
+	roll 60, Sphero::FORWARD
 	keep_going 3
 
-	roll 60, RIGHT
+	roll 60, Sphero::RIGHT
 	keep_going 3
 
-	roll 60, BACKWARD
+	roll 60, Sphero::BACKWARD
 	keep_going 3
 
-	roll 60, LEFT
+	roll 60, Sphero::LEFT
 	keep_going 3
 
 	stop


### PR DESCRIPTION
Reference: http://ruby-dev.info/posts/43365 (fixed in 1.9.3)
It should be safe to use fully-qualified constant names in the block passed to instance_eval.
