### PR TITLE
Empty string default param for puts

### DIFF
--- a/lib/kidsruby/stdio.rb
+++ b/lib/kidsruby/stdio.rb
@@ -5,7 +5,7 @@ class KidsRubyStdIo
     @interface = interface
   end
 
-  def puts(data)
+  def puts(data="")
     write(data.to_s + "\n")
   end
 


### PR DESCRIPTION
This allows puts to be called with an empty string so that minitest can be used within the editor.
